### PR TITLE
Make nrpe_pip_checks empty by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ nrpe_check_mode: "0555"
 nrpe_check_backup: "no"
 
 nrpe_pip_checks:
- - { name: "nagiosplugin" }
+ - { name: "" }
 
 nrpe_python_packages:
  - python-pip


### PR DESCRIPTION
Previously nrpe_pip_checks had a one entry list as its default where
that entry was "nagiosplugin". This caused the pip checks to always be
installed. Remove nagiosplugin so that the default is to not install pip
checks.
