### PR TITLE
Allow setting SELinux file contexts for checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is not a place where to store nagios checks. It can:
 
  - get_url of a remote file (and check checksum)
  - copy of a local file, perhaps available in files/
+ - set SELinux file contexts for checks if needed
 
 Configuring nrpe, restarting nrpe is not part of this role.
 
@@ -26,6 +27,8 @@ nrpe_remote_url_checks:
  - { url: "http://url1/check_elasticsearch", name: "check_elasticsearch", checksum: "7e39171be1095b3c6a35c9649e3d5e73bcf76a3647b99fd7a205248a35d6a6f9" }
 nrpe_local_checks:
  - { path: "files/check_custom2", name: "check_custom2" }
+nrpe_check_selinux_contexts:
+ - { target: "files/check_custom2", setype: "nagios_unconfined_plugin_exec_t", state: "present" }
 </pre>
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,7 @@ nrpe_pip_checks:
 
 nrpe_python_packages:
  - python-pip
+
+# Set SELinux file contexts for check scripts
+#nrpe_check_selinux_contexts:
+# - { target: "/usr/bin/pynagsystemd.py", setype: "nagios_unconfined_plugin_exec_t", state: "present" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,4 +25,20 @@
  - name: install dependencies with pip
    pip: name='{{ item.name }}' state=present
    with_items: "{{ nrpe_pip_checks }}"
-   when: nrpe_pip_checks.0.name != "" 
+   when: nrpe_pip_checks.0.name != ""
+
+ - name: set SELinux contexts for checks
+   sefcontext:
+     target: "{{ item.target }}"
+     setype: "{{ item.setype }}"
+     state: "{{ item.state }}"
+   with_items: "{{ nrpe_check_selinux_contexts }}"
+   register: set_selinux_contexts
+   when: nrpe_check_selinux_contexts is defined
+
+ - name: refresh SELinux context for checks
+   command: "restorecon {{ item.target }}"
+   with_items: "{{ nrpe_check_selinux_contexts }}"
+   when:
+     - nrpe_check_selinux_contexts is defined
+     - set_selinux_contexts.changed


### PR DESCRIPTION
Add a mechanism that will set freely defined SELinux contexts for a list
of freely defined check scripts. The check scripts can be installed via
any mechanism - pip, copied locally, URL etc.