### PR TITLE
More testing of this role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-role-nrpe-plugins
 =========
 
-[![Build Status](https://travis-ci.org/CSC-IT-Center-for-Science/ansible-role-nrpe-plugins.svg?branch=master)](https://travis-ci.org/CSC-IT-Center-for-Science/ansible-role-nrpe-plugins)
+[![Build Status](https://travis-ci.org/CSCfi/ansible-role-nrpe-plugins.svg?branch=master)](https://travis-ci.org/CSCfi/ansible-role-nrpe-plugins)
 
 This is not a place where to store nagios checks. It can:
 
@@ -34,7 +34,7 @@ nrpe_check_selinux_contexts:
 Dependencies
 ------------
 
-https://github.com/CSC-IT-Center-for-Science/ansible-role-nrpe
+https://github.com/CSCfi/ansible-role-nrpe
 
 Example Playbook
 ----------------

--- a/tests/files/check_example.sh
+++ b/tests/files/check_example.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# This is just an example check so that we can test this role a bit more.
+
+used_space=`df -h / | grep -v Filesystem | awk '{print $5}' | sed 's/%//g'`
+case $used_space in
+[1-84]*)
+echo "OK - $used_space% of disk space used."
+exit 0
+;;
+[85]*)
+echo "WARNING - $used_space% of disk space used."
+exit 1
+;;
+[86-100]*)
+echo "CRITICAL - $used_space% of disk space used."
+exit 2
+;;
+*)
+echo "UNKNOWN - $used_space% of disk space used."
+exit 3
+;;
+esac

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,5 +8,24 @@
      - nrpe_local_checks:
        - { path: "files/check_example.sh", name: "check_example" }
 
+   pre_tasks:
+     - name: create nrpe_group
+       group:
+               state: present
+               name: "{{ nrpe_group }}"
+     - name: create nrpe_user
+       user:
+               state: present
+               name: "{{ nrpe_user }}"
+               group: "{{ nrpe_group }}"
+     - name: create nagiosdir
+       file:
+               path: "{{ nrpe_check_location }}"
+               state: directory
+               owner: "{{ nrpe_user }}"
+               group: "{{ nrpe_group }}"
+               mode: 0775
+
+
    roles:
      - ansible-role-nrpe-plugins

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,5 +2,9 @@
 
  - hosts: localhost
    remote_user: root
+   vars:
+     - nrpe_pip_checks:
+       - { name: "nagiosplugin" }
+
    roles:
      - ansible-role-nrpe-plugins

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,6 +5,8 @@
    vars:
      - nrpe_pip_checks:
        - { name: "nagiosplugin" }
+     - nrpe_local_checks:
+       - { path: "files/check_example.sh", name: "check_example" }
 
    roles:
      - ansible-role-nrpe-plugins


### PR DESCRIPTION
 - also rename CSCorganization
 - install an example check

(Not testing selinux as at least ansible thinks it's disabled inside the container (and the hosts in travis run Ubuntu so might not be possible to accomplish))